### PR TITLE
Give control on how and when the App Launch happens and More

### DIFF
--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/TestsGeneratorPhase.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/TestsGeneratorPhase.kt
@@ -4,6 +4,7 @@ import co.touchlab.kmp.testing.framework.compiler.phase.tests.generator.AndroidT
 import co.touchlab.kmp.testing.framework.compiler.phase.tests.generator.IOSTestsEntryPointGenerator
 import co.touchlab.kmp.testing.framework.compiler.phase.tests.generator.UnitTestsEntryPointGenerator
 import co.touchlab.kmp.testing.framework.compiler.setup.androidAppEntryPoint
+import co.touchlab.kmp.testing.framework.compiler.setup.androidAppEntryPointType
 import co.touchlab.kmp.testing.framework.compiler.setup.androidTestsGeneratorOutputPath
 import co.touchlab.kmp.testing.framework.compiler.setup.iOSTestsGeneratorOutputPath
 import co.touchlab.kmp.testing.framework.compiler.setup.unitTestsGeneratorOutputPath
@@ -18,7 +19,7 @@ class TestsGeneratorPhase(
 
     private val generators = listOf(
         UnitTestsEntryPointGenerator(configuration.unitTestsGeneratorOutputPath),
-        AndroidTestsEntryPointGenerator(configuration.androidTestsGeneratorOutputPath, configuration.androidAppEntryPoint),
+        AndroidTestsEntryPointGenerator(configuration.androidTestsGeneratorOutputPath, configuration.androidAppEntryPoint, configuration.androidAppEntryPointType),
         IOSTestsEntryPointGenerator(configuration.iOSTestsGeneratorOutputPath),
     )
 

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/descriptor/DriverDescriptor.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/descriptor/DriverDescriptor.kt
@@ -3,12 +3,14 @@ package co.touchlab.kmp.testing.framework.compiler.phase.tests.descriptor
 import co.touchlab.kmp.testing.framework.compiler.util.getRequiredImport
 import co.touchlab.kmp.testing.framework.compiler.util.partiallyQualifiedName
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.packageFqName
 
 data class DriverDescriptor(
     val partiallyQualifiedName: String,
     val packageName: String,
+    val hasOnFinally: Boolean,
 ) {
 
     fun getRequiredImports(fromPackage: String): Set<String> =
@@ -18,7 +20,8 @@ data class DriverDescriptor(
 
         fun from(driverClass: IrClass): DriverDescriptor = DriverDescriptor(
             partiallyQualifiedName = driverClass.kotlinFqName.partiallyQualifiedName,
-            packageName = driverClass.packageFqName?.asString() ?: ""
+            packageName = driverClass.packageFqName?.asString() ?: "",
+            hasOnFinally = driverClass.functions.any { it.name.asString() == "onFinally" }
         )
     }
 }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/AndroidTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/AndroidTestsEntryPointGenerator.kt
@@ -68,7 +68,11 @@ class AndroidTestsEntryPointGenerator(
         
                 val contracts = suite.${contracts.contractsClassName}()
         
-                contracts.action()
+                try {
+                    contracts.action()
+                } finally {
+                    ${if(driver.hasOnFinally) "driver.onFinally()" else ""}
+                }
             }
             """.trimIndent()
     }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/AndroidTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/AndroidTestsEntryPointGenerator.kt
@@ -42,7 +42,7 @@ class AndroidTestsEntryPointGenerator(
         +"""
             import $androidAppEntryPoint
             import androidx.compose.ui.test.junit4.createComposeRule
-            import androidx.compose.ui.test.junit4.createAndroidComposeRule
+            import androidx.compose.ui.test.junit4.createEmptyComposeRule
             import org.junit.Rule
             import org.junit.Test
             
@@ -62,7 +62,7 @@ class AndroidTestsEntryPointGenerator(
             private inline fun runTest(action: ${contracts.contractsClassPartiallyQualifiedName}.() -> Unit) {
                 ${content()}
                 
-                val driver = ${driver.partiallyQualifiedName}(composeTestRule)
+                val driver = ${driverInstantiation()}
             
                 val suite = ${contracts.suiteName}(driver)
         
@@ -100,7 +100,13 @@ class AndroidTestsEntryPointGenerator(
     private fun buildComposeTestRule(): String =
         when(androidInitializationStrategy) {
             AndroidInitializationStrategy.COMPOSABLE -> "createComposeRule()"
-            AndroidInitializationStrategy.ACTIVITY -> "createAndroidComposeRule<${entryPointSimpleName()}>()"
+            AndroidInitializationStrategy.ACTIVITY -> "createEmptyComposeRule()"
+        }
+
+    private fun TestsSuiteInstanceDescriptor.driverInstantiation(): String =
+        when(androidInitializationStrategy) {
+            AndroidInitializationStrategy.COMPOSABLE -> "${driver.partiallyQualifiedName}(composeTestRule)"
+            AndroidInitializationStrategy.ACTIVITY -> "${driver.partiallyQualifiedName}(composeTestRule, ${entryPointSimpleName()}::class.java)"
         }
 
     private fun entryPointSimpleName(): String = androidAppEntryPoint.substringAfterLast(".")

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/BaseTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/BaseTestsEntryPointGenerator.kt
@@ -5,6 +5,7 @@ import co.touchlab.kmp.testing.framework.compiler.phase.tests.descriptor.DriverD
 import co.touchlab.kmp.testing.framework.compiler.phase.tests.descriptor.TestsSuiteDescriptor
 import co.touchlab.kmp.testing.framework.compiler.phase.tests.descriptor.TestsSuiteInstanceDescriptor
 import co.touchlab.kmp.testing.framework.compiler.util.SmartStringBuilder
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
 
@@ -37,6 +38,8 @@ abstract class BaseTestsEntryPointGenerator(
 
             testsSuiteInstanceDescriptor.appendCode()
         }
+
+        Files.createDirectories(outputFile.parent)
 
         outputFile.writeText(fileContent)
     }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/IOSTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/IOSTestsEntryPointGenerator.kt
@@ -49,6 +49,8 @@ class IOSTestsEntryPointGenerator(
                         
                 try action(contracts)
                 
+                ${if(driver.hasOnFinally) "driver.onFinally()" else ""}
+                
                 app.terminate()
             }
             """.trimIndent()

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/IOSTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/IOSTestsEntryPointGenerator.kt
@@ -41,8 +41,6 @@ class IOSTestsEntryPointGenerator(
             private func runTest(action: (${contracts.contractsClassPartiallyQualifiedName}) throws -> Void) rethrows {
                 let app = XCUIApplication()
                         
-                app.launch()
-                        
                 let driver = ${driver.partiallyQualifiedName}(app: app)
                         
                 let suite = ${contracts.suiteName}(driver: driver)
@@ -50,6 +48,8 @@ class IOSTestsEntryPointGenerator(
                 let contracts = ${contracts.contractsClassPartiallyQualifiedName}(suite)
                         
                 try action(contracts)
+                
+                app.terminate()
             }
             """.trimIndent()
     }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/UnitTestsEntryPointGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/phase/tests/generator/UnitTestsEntryPointGenerator.kt
@@ -49,7 +49,11 @@ class UnitTestsEntryPointGenerator(
         
                 val contracts = suite.${contracts.contractsClassName}()
         
-                contracts.action()
+                try {
+                    contracts.action()
+                } finally {
+                    ${if(driver.hasOnFinally) "driver.onFinally()" else ""}
+                }
             }
             """.trimIndent()
     }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/AndroidInitializationStrategy.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/AndroidInitializationStrategy.kt
@@ -1,0 +1,10 @@
+package co.touchlab.kmp.testing.framework.compiler.setup
+
+enum class AndroidInitializationStrategy {
+    COMPOSABLE, ACTIVITY;
+
+    companion object {
+        fun byName(name: String): AndroidInitializationStrategy =
+            entries.first { it.name.equals(name, ignoreCase = true) }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/PluginCommandLineProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/PluginCommandLineProcessor.kt
@@ -17,6 +17,7 @@ class PluginCommandLineProcessor : CommandLineProcessor {
         Options.iOSTestsGeneratorOutputPath,
         Options.unitTestsGeneratorOutputPath,
         Options.androidAppEntryPoint,
+        Options.androidAppEntryPointType,
     )
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
@@ -27,6 +28,7 @@ class PluginCommandLineProcessor : CommandLineProcessor {
             Options.iOSTestsGeneratorOutputPath.optionName -> configuration.iOSTestsGeneratorOutputPath = Paths.get(value)
             Options.unitTestsGeneratorOutputPath.optionName -> configuration.unitTestsGeneratorOutputPath = Paths.get(value)
             Options.androidAppEntryPoint.optionName -> configuration.androidAppEntryPoint = value
+            Options.androidAppEntryPointType.optionName -> configuration.androidAppEntryPointType = AndroidInitializationStrategy.byName(value)
         }
     }
 
@@ -61,6 +63,13 @@ class PluginCommandLineProcessor : CommandLineProcessor {
             valueDescription = "function FQ name",
             description = "FQ name of the Composable function which the UI tests should call to setup the app.",
             required = true,
+            allowMultipleOccurrences = false,
+        )
+        val androidAppEntryPointType = CliOption(
+            optionName = "androidAppEntryPointType",
+            valueDescription = "<Activity|Composable> default: Composable",
+            description = "Defines the entrypoint initialization strategy.",
+            required = false,
             allowMultipleOccurrences = false,
         )
     }

--- a/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/PluginConfigurationKeys.kt
+++ b/compiler-plugin/src/main/kotlin/co/touchlab/kmp/testing/framework/compiler/setup/PluginConfigurationKeys.kt
@@ -11,6 +11,7 @@ object PluginConfigurationKeys {
     object UnitTestsGeneratorOutputPath : CompilerConfigurationKey<Path>("UnitTestsGeneratorOutputPath")
 
     object AndroidAppEntryPoint : CompilerConfigurationKey<String>("AndroidAppEntryPoint")
+    object AndroidAppEntryPointType : CompilerConfigurationKey<AndroidInitializationStrategy>("AndroidAppEntryPointType")
 }
 
 var CompilerConfiguration.androidTestsGeneratorOutputPath: Path
@@ -28,3 +29,7 @@ var CompilerConfiguration.unitTestsGeneratorOutputPath: Path
 var CompilerConfiguration.androidAppEntryPoint: String
     get() = getNotNull(PluginConfigurationKeys.AndroidAppEntryPoint)
     set(value) = put(PluginConfigurationKeys.AndroidAppEntryPoint, value)
+
+var CompilerConfiguration.androidAppEntryPointType: AndroidInitializationStrategy
+    get() = get(PluginConfigurationKeys.AndroidAppEntryPointType) ?: AndroidInitializationStrategy.COMPOSABLE
+    set(value) = put(PluginConfigurationKeys.AndroidAppEntryPointType, value)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.0"
+kotlin = "2.0.21"
 jdk = "8"
 
 [plugins]


### PR DESCRIPTION
This PR give control to the UI native drivers to control how and when they want to start the application, this is useful for Injecting on the app startup.

Adds support for Activity Compose Test Rule type by providing the activity and composeTestRule to the Android Driver.

Adds a call to a function named `onFinally` if is present in the Class IR, when the test ends it execution.